### PR TITLE
Decrease UndecidingTimeout

### DIFF
--- a/runtime/src/governance/mod.rs
+++ b/runtime/src/governance/mod.rs
@@ -51,7 +51,7 @@ impl pallet_conviction_voting::Config for Runtime {
 parameter_types! {
 	pub const AlarmInterval: BlockNumber = 1;
 	pub const SubmissionDeposit: Balance = 100 * UNITS;
-	pub const UndecidingTimeout: BlockNumber = 28 * DAYS;
+	pub const UndecidingTimeout: BlockNumber = 1 * HOURS;
 }
 
 parameter_types! {


### PR DESCRIPTION
It will be more convenient to test Timed Out state of Referendum if UndecidingTimeout would be lower